### PR TITLE
FileProvider: robust write/read handling, remove old files on overwrite, and add tests

### DIFF
--- a/src/main/java/ru/vzmx/app/cache/providers/FileProvider.java
+++ b/src/main/java/ru/vzmx/app/cache/providers/FileProvider.java
@@ -45,8 +45,11 @@ public class FileProvider<K, V> implements Provider<K, V> {
     @Override
     public void put(K key, V value) {
         String fileName = UUID.randomUUID().toString();
-        keyToFileMapping.put(key, fileName);
         writeToFile(fileName, value);
+        String oldFileName = keyToFileMapping.put(key, fileName);
+        if (oldFileName != null) {
+            removeFile(oldFileName);
+        }
     }
 
     @Override
@@ -62,13 +65,13 @@ public class FileProvider<K, V> implements Provider<K, V> {
 
     private void writeToFile(String fileName, V value) {
         try (
-                FileOutputStream fout = new FileOutputStream(getFile(fileName), true);
+                FileOutputStream fout = new FileOutputStream(getFile(fileName));
                 ObjectOutputStream oos = new ObjectOutputStream(fout)
         ) {
             oos.writeObject(value);
         } catch (Exception ex) {
-            // in case of error we could made some cleanup but not for this simple implementation
-            ex.printStackTrace();
+            removeFile(fileName);
+            throw new IllegalStateException("Cannot write cache value to file: " + fileName, ex);
         }
     }
 
@@ -84,10 +87,8 @@ public class FileProvider<K, V> implements Provider<K, V> {
             //noinspection unchecked
             return (V) ois.readObject();
         } catch (Exception ex) {
-            // it may be useful to delete file if it is corrupted but not for this simple implementation
-            ex.printStackTrace();
+            throw new IllegalStateException("Cannot read cache value from file: " + fileName, ex);
         }
-        return null;
     }
 
     private boolean removeFile(String fileName) {

--- a/src/test/java/ru/vzmx/app/cache/FileCacheTest.java
+++ b/src/test/java/ru/vzmx/app/cache/FileCacheTest.java
@@ -1,19 +1,64 @@
 package ru.vzmx.app.cache;
 
+import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import ru.vzmx.app.cache.providers.FileProvider;
 import ru.vzmx.app.cache.strategies.FIFOCacheStrategy;
 
-import java.nio.file.Paths;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
 
 public class FileCacheTest extends CommonCacheTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
     @Test
-    public void fileCacheOneValueTest() {
+    public void fileCacheOneValueTest() throws IOException {
         oneValueTest(
                 new LeveledCache<>(
                         new FIFOCacheStrategy<>(),
-                        new FileProvider<>(Paths.get("one-value-dir")),
+                        new FileProvider<>(temporaryFolder.newFolder("one-value-dir").toPath()),
                         10)
         );
+    }
+
+    @Test
+    public void overwrittenKeyKeepsOnlyLatestFile() throws IOException {
+        Path cacheDir = temporaryFolder.newFolder("overwrite-dir").toPath();
+        Provider<String, Integer> provider = new FileProvider<>(cacheDir);
+
+        provider.put(key1, 1);
+        provider.put(key1, 2);
+
+        Assert.assertEquals(1, provider.size());
+        Assert.assertEquals(1, countFiles(cacheDir));
+        Assert.assertEquals(2, (int) provider.get(key1).orElseThrow(AssertionError::new));
+    }
+
+    @Test
+    public void failedWriteDoesNotRegisterKey() throws IOException {
+        Path cacheDir = temporaryFolder.newFolder("failed-write-dir").toPath();
+        Provider<String, Object> provider = new FileProvider<>(cacheDir);
+
+        try {
+            provider.put(key1, new Object());
+            Assert.fail("Expected write to fail for non-serializable value");
+        } catch (IllegalStateException expected) {
+            // expected
+        }
+
+        Assert.assertFalse(provider.containsKey(key1));
+        Assert.assertEquals(0, provider.size());
+        Assert.assertEquals(0, countFiles(cacheDir));
+    }
+
+    private long countFiles(Path cacheDir) throws IOException {
+        try (Stream<Path> files = Files.list(cacheDir)) {
+            return files.count();
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent leaking stale files and ensure a cache `put` either fully succeeds or fails without registering a broken entry.
- Surface I/O errors instead of silently printing stack traces to make failures detectable by callers.
- Add unit tests to verify overwrite behavior and failure handling for the file-backed provider.

### Description
- Change `FileProvider.put` to write the new file first, then update the `keyToFileMapping`, and remove the previous file if present to avoid orphaned files.
- Update `writeToFile` to open `FileOutputStream` without append mode, delete the file on write failure, and throw `IllegalStateException` on errors.
- Update `readFromFile` to throw `IllegalStateException` on read errors instead of printing the exception and returning `null`.
- Add tests in `FileCacheTest` to use a `TemporaryFolder`, and add `overwrittenKeyKeepsOnlyLatestFile` and `failedWriteDoesNotRegisterKey` tests plus a helper `countFiles` method.

### Testing
- Ran unit tests under `FileCacheTest` which include `fileCacheOneValueTest`, `overwrittenKeyKeepsOnlyLatestFile`, and `failedWriteDoesNotRegisterKey`.
- All added tests passed when executed locally with the test suite.
- Existing cache tests from `CommonCacheTest` were run as part of the suite and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee29b0eb7c832a8ed44e21be396d05)